### PR TITLE
FixCI

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   check_release:


### PR DESCRIPTION
I thought it might be a problem with the following repositories because `check-link` was giving me an error, so I investigated.

- https://github.com/jupyterlab/pytest-check-links
- https://github.com/jupyterlab/extension-cookiecutter-ts

However, it turned out to be a Github issue or specification that prevented me from getting status badges for private repositories.
- https://github.community/t/workflow-actions-status-badge-giving-404-on-private-repo-in-an-organization/16242/11
